### PR TITLE
Moving `$.fail()` so stopLoader is called on actual fail

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/stripe.js
+++ b/view/frontend/web/js/view/payment/method-renderer/stripe.js
@@ -380,11 +380,11 @@ define([
                     fullScreenLoader.stopLoader(true);
 
                 });
-            }).fail(function() {
-                fullScreenLoader.stopLoader(true);
-                self.isPlaceOrderActionAllowed(true);
-            });
-          })
+            })
+          }).fail(function() {
+            fullScreenLoader.stopLoader(true);
+            self.isPlaceOrderActionAllowed(true);
+        });
       },
       getReturnUrl: function () {
         return window.checkoutConfig.payment[this.getCode()].returnUrl;


### PR DESCRIPTION
Moving `$.fail()` method from `createPaymentIntent` to `createMethodByCart` to fix validation issues where stopLoader is never called upon faulty checkout submission.

The loader screen is never hidden after entering a credit card number, but leaving expiration or CVC blank, and clicking submit.

Addresses issue on https://github.com/PowerSync/TNW_Stripe/issues/61