### PR TITLE
M2 s 14 a source must be attached

### DIFF
--- a/Gateway/Http/Client/TransactionSale.php
+++ b/Gateway/Http/Client/TransactionSale.php
@@ -28,7 +28,7 @@ class TransactionSale extends AbstractTransaction
         $storeId = $data['store_id'] ? $data['store_id'] : null;
         // sending store id and other additional keys are restricted by Stripe API
         unset($data['store_id']);
-        unset($data['source']);
+        unset($data['payment_method']);
         unset($data['shipping']);
 
         return $this->adapterFactory->create($storeId)

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnw/module-stripe",
   "description": "Stripe Payments for Magento 2",
   "type": "magento2-module",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "license": "OSL-3.0",
   "require": {
     "magento/framework": ">100",


### PR DESCRIPTION
This issue is only occuring, when placing an Order in the Backend (Admin). Now the Payment is going through and both Payment Source and Payment Intent are being created in the Stripe API. 