### PR TITLE
Add email and description for guest and for customer with is_vault_en…

### DIFF
--- a/Console/Command/GuestOrder.php
+++ b/Console/Command/GuestOrder.php
@@ -1,0 +1,76 @@
+<?php
+namespace TNW\Stripe\Console\Command;
+
+use Magento\Framework\App\Area;
+use Magento\Framework\App\State;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use TNW\Stripe\Model\Order\Guest;
+/**
+ * Class GuestOrder
+ * @package TNW\Stripe\Console\Command
+ */
+class GuestOrder extends Command
+{
+    /**
+     * @var Guest
+     */
+    protected $guest;
+
+    /**
+     * @var State
+     */
+    protected $appState;
+
+    /**
+     * GuestOrder constructor.
+     * @param Guest $guest
+     * @param State $appState
+     * @param string|null $name
+     */
+    public function __construct(
+        Guest $guest,
+        State $appState,
+        string $name = null
+    ) {
+        $this->guest = $guest;
+        $this->appState = $appState;
+        parent::__construct($name);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this->setName('tnw:exportguestorders');
+        $this->setDescription('Export Guest Orders to Stripe');
+
+        parent::configure();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->appState->emulateAreaCode(Area::AREA_FRONTEND, [$this, 'export'], [$input, $output]);
+
+    }
+
+    /**
+     * @param $input
+     * @param $output
+     */
+    public function export($input, $output)
+    {
+        $response = $this->guest->exportGuestOrders();
+        if (!empty($response) && is_array($response)) {
+            $output->writeln("There were errors on Guest orders export to Stripe: ");
+                print_r($response);
+        } else {
+            $output->writeln("Guest orders export to Stripe done.");
+        }
+    }
+}

--- a/Console/Command/GuestOrder.php
+++ b/Console/Command/GuestOrder.php
@@ -7,9 +7,9 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use TNW\Stripe\Model\Order\Guest;
+
 /**
  * Class GuestOrder
- * @package TNW\Stripe\Console\Command
  */
 class GuestOrder extends Command
 {
@@ -46,7 +46,6 @@ class GuestOrder extends Command
     {
         $this->setName('tnw:exportguestorders');
         $this->setDescription('Export Guest Orders to Stripe');
-
         parent::configure();
     }
 
@@ -56,7 +55,6 @@ class GuestOrder extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->appState->emulateAreaCode(Area::AREA_FRONTEND, [$this, 'export'], [$input, $output]);
-
     }
 
     /**

--- a/Console/Command/GuestOrder.php
+++ b/Console/Command/GuestOrder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace TNW\Stripe\Console\Command;
 
 use Magento\Framework\App\Area;
@@ -9,7 +10,8 @@ use Symfony\Component\Console\Output\OutputInterface;
 use TNW\Stripe\Model\Order\Guest;
 
 /**
- * Class GuestOrder
+ * Class GuestOrder.
+ * Console command responsible for actualizing guest orders in Stripe.
  */
 class GuestOrder extends Command
 {

--- a/Controller/PaymentIntent/Create.php
+++ b/Controller/PaymentIntent/Create.php
@@ -99,7 +99,6 @@ class Create extends Action\Action
                 'metadata' => ['site' => $this->_url->getBaseUrl()]
             ];
 
-
             // for login customers while enable vault in configuration and vault not checked in frontend case
             $email = $this->checkoutSession->getQuote()->getBillingAddress()->getEmail();
             $isLoggedIn = $this->session->isLoggedIn();

--- a/Controller/PaymentIntent/Create.php
+++ b/Controller/PaymentIntent/Create.php
@@ -14,8 +14,7 @@ use Magento\Checkout\Model\Session as CheckoutSession;
 
 /**
  * Class Create
- *
- * @package TNW\Stripe\Controller\Paymentintent
+ * Perform Payment and Customer Api requests to Stripe.
  */
 class Create extends Action\Action
 {
@@ -102,9 +101,9 @@ class Create extends Action\Action
             // for login customers while enable vault in configuration and vault not checked in frontend case
             $email = $this->checkoutSession->getQuote()->getBillingAddress()->getEmail();
             $isLoggedIn = $this->session->isLoggedIn();
-            if (($isLoggedIn)) {
+            if ($isLoggedIn) {
                 $attributes['email'] = $email;
-            } elseif (!$isLoggedIn) {
+            } else {
                 $attributes['email'] = $email;
                 $attributes['description'] = 'guest';
             }

--- a/Gateway/Helper/SubjectReader.php
+++ b/Gateway/Helper/SubjectReader.php
@@ -19,10 +19,12 @@ use Magento\Payment\Gateway\Helper;
 
 class SubjectReader
 {
-  /**
-   * @param array $subject
-   * @return array
-   */
+    const TRANSACTION_DESCRIPTION = 'Order #';
+
+    /**
+     * @param array $subject
+     * @return array
+     */
     public function readResponseObject(array $subject)
     {
         $response = Helper\SubjectReader::readResponse($subject);
@@ -33,8 +35,8 @@ class SubjectReader
 
         if ($response['object'] instanceof \Stripe\ErrorObject) {
             return [
-            'error' => true,
-            'message' => __($response['object']->getMessage())
+                'error' => true,
+                'message' => __($response['object']->getMessage())
             ];
         }
 
@@ -67,5 +69,11 @@ class SubjectReader
         }
 
         return (int) $subject['customer_id'];
+    }
+
+    public function getOrderIncrementId(\Magento\Sales\Api\Data\OrderPaymentInterface $payment)
+    {
+        $incrementId = $payment->getOrder()->getIncrementId();
+        return SELF::TRANSACTION_DESCRIPTION . $incrementId;
     }
 }

--- a/Gateway/Helper/SubjectReader.php
+++ b/Gateway/Helper/SubjectReader.php
@@ -20,7 +20,7 @@ use Magento\Sales\Api\Data\OrderPaymentInterface;
 
 /**
  * Class SubjectReader
- * @package TNW\Stripe\Gateway\Helper
+ * Helper for reading API responses.
  */
 class SubjectReader
 {
@@ -76,6 +76,10 @@ class SubjectReader
         return (int) $subject['customer_id'];
     }
 
+    /**
+     * @param OrderPaymentInterface $payment
+     * @return string
+     */
     public function getOrderIncrementId(OrderPaymentInterface $payment)
     {
         return SELF::TRANSACTION_DESCRIPTION . $payment->getOrder()->getIncrementId();

--- a/Gateway/Helper/SubjectReader.php
+++ b/Gateway/Helper/SubjectReader.php
@@ -16,7 +16,12 @@
 namespace TNW\Stripe\Gateway\Helper;
 
 use Magento\Payment\Gateway\Helper;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
 
+/**
+ * Class SubjectReader
+ * @package TNW\Stripe\Gateway\Helper
+ */
 class SubjectReader
 {
     const TRANSACTION_DESCRIPTION = 'Order #';
@@ -71,9 +76,8 @@ class SubjectReader
         return (int) $subject['customer_id'];
     }
 
-    public function getOrderIncrementId(\Magento\Sales\Api\Data\OrderPaymentInterface $payment)
+    public function getOrderIncrementId(OrderPaymentInterface $payment)
     {
-        $incrementId = $payment->getOrder()->getIncrementId();
-        return SELF::TRANSACTION_DESCRIPTION . $incrementId;
+        return SELF::TRANSACTION_DESCRIPTION . $payment->getOrder()->getIncrementId();
     }
 }

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -27,7 +27,7 @@ use TNW\Stripe\Gateway\Config\Config;
 class PaymentDataBuilder implements BuilderInterface
 {
     use Formatter;
-  
+
     const AMOUNT = 'amount';
     const CURRENCY = 'currency';
     const DESCRIPTION = 'description';
@@ -74,7 +74,8 @@ class PaymentDataBuilder implements BuilderInterface
             self::CURRENCY => $order->getCurrencyCode(),
             self::PAYMENT_METHOD_TYPES => ['card'],
             self::CONFIRMATION_METHOD => 'manual',
-            self::CAPTURE_METHOD => 'manual'
+            self::CAPTURE_METHOD => 'manual',
+            self::DESCRIPTION => $this->subjectReader->getOrderIncrementId($payment)
         ];
 
         if ($this->config->isReceiptEmailEnabled()) {

--- a/Gateway/Request/PaymentDataBuilder.php
+++ b/Gateway/Request/PaymentDataBuilder.php
@@ -27,7 +27,7 @@ use TNW\Stripe\Gateway\Config\Config;
 class PaymentDataBuilder implements BuilderInterface
 {
     use Formatter;
-
+  
     const AMOUNT = 'amount';
     const CURRENCY = 'currency';
     const DESCRIPTION = 'description';

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -2,9 +2,10 @@
 namespace TNW\Stripe\Helper;
 
 use Magento\Customer\Api\CustomerRepositoryInterface;
+
 /**
- * Class Customer
- * @package TNW\Stripe\Helper
+ * Class Customer.
+ * Updates stripe_id customer attribute.
  */
 class Customer
 {
@@ -35,7 +36,6 @@ class Customer
     {
         try {
             $customer = $this->customerRepository->get($email);
-            //$customer->setData('stripe_id', $cs);
             $customer->setCustomAttribute('stripe_id', $cs);
             $this->customerRepository->save($customer);
         } catch (\Exception $exception) {

--- a/Helper/Customer.php
+++ b/Helper/Customer.php
@@ -1,0 +1,45 @@
+<?php
+namespace TNW\Stripe\Helper;
+
+use Magento\Customer\Api\CustomerRepositoryInterface;
+/**
+ * Class Customer
+ * @package TNW\Stripe\Helper
+ */
+class Customer
+{
+    /**
+     * @var CustomerRepositoryInterface
+     */
+    protected $customerRepository;
+
+    /**
+     * Customer constructor.
+     * @param CustomerRepositoryInterface $customerRepository
+     */
+    public function __construct(
+        CustomerRepositoryInterface $customerRepository
+    ) {
+        $this->customerRepository = $customerRepository;
+    }
+
+    /**
+     * @param $email
+     * @param $cs
+     * @throws \Magento\Framework\Exception\InputException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\State\InputMismatchException
+     */
+    public function updateCustomerStripeId($email, $cs)
+    {
+        try {
+            $customer = $this->customerRepository->get($email);
+            //$customer->setData('stripe_id', $cs);
+            $customer->setCustomAttribute('stripe_id', $cs);
+            $this->customerRepository->save($customer);
+        } catch (\Exception $exception) {
+            unset($exception);
+        }
+    }
+}

--- a/Model/Adapter/StripeAdapter.php
+++ b/Model/Adapter/StripeAdapter.php
@@ -90,7 +90,9 @@ class StripeAdapter
             $pi = PaymentIntent::create($attributes);
         } else {
             $pi = PaymentIntent::retrieve($attributes['pi']);
-            if (isset($attributes['description'])) $pi->update($attributes['pi'], ['description' => $attributes['description']]);
+            if (isset($attributes['description'])) {
+                $pi->update($attributes['pi'], ['description' => $attributes['description']]);
+            }
         }
         if ($pi->status == 'requires_confirmation') {
             $pi->confirm();
@@ -141,6 +143,12 @@ class StripeAdapter
             Customer::update($id, $attributes);
             $cs = Customer::retrieve($id);
             return $cs;
+        } elseif (isset($attributes['email'])) {
+            foreach (Customer::all() as $customer) {
+                if ($attributes['email'] == $customer->email && $customer->metadata->site == $attributes['metadata']['site']) {
+                    return $customer;
+                }
+            }
         }
         return Customer::create($attributes);
     }
@@ -163,6 +171,17 @@ class StripeAdapter
     public function retrievePaymentIntent ($transactionId)
     {
         return PaymentIntent::retrieve($transactionId);
+    }
+
+    /**
+     * @param $id
+     * @param $attributes
+     * @return Customer
+     * @throws \Stripe\Exception\ApiErrorException
+     */
+    public function updateCustomer($id, $attributes)
+    {
+        return Customer::update($id, $attributes);
     }
 
     /**

--- a/Model/Adapter/StripeAdapter.php
+++ b/Model/Adapter/StripeAdapter.php
@@ -90,6 +90,7 @@ class StripeAdapter
             $pi = PaymentIntent::create($attributes);
         } else {
             $pi = PaymentIntent::retrieve($attributes['pi']);
+            if (isset($attributes['description'])) $pi->update($attributes['pi'], ['description' => $attributes['description']]);
         }
         if ($pi->status == 'requires_confirmation') {
             $pi->confirm();

--- a/Model/Order/Guest.php
+++ b/Model/Order/Guest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace TNW\Stripe\Model\Order;
+
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
+use TNW\Stripe\Helper\Customer as CustomerHelper;
+use TNW\Stripe\Model\Adapter\StripeAdapterFactory;
+use TNW\Stripe\Helper\Payment\Formatter;
+/**
+ * Class Guest
+ * @package TNW\Stripe\Model\Order
+ */
+class Guest
+{
+    use Formatter;
+
+    /**
+     * @var CollectionFactory
+     */
+    protected $orderCollectionFactory;
+
+    /**
+     * @var StripeAdapterFactory
+     */
+    private $adapterFactory;
+
+    /**
+     * @var CustomerHelper
+     */
+    protected $customerHelper;
+
+    /**
+     * Guest constructor.
+     * @param CollectionFactory $collectionFactory
+     * @param StripeAdapterFactory $adapterFactory
+     * @param CustomerHelper $customerHelper
+     */
+    public function __construct(
+        CollectionFactory $collectionFactory,
+        StripeAdapterFactory $adapterFactory,
+        CustomerHelper $customerHelper
+    ) {
+        $this->orderCollectionFactory = $collectionFactory;
+        $this->adapterFactory = $adapterFactory;
+        $this->customerHelper = $customerHelper;
+    }
+
+    /**
+     * @return Collection
+     */
+    public function getGuestOrders()
+    {
+        /**
+         * @var Collection $orderCollecion
+         */
+        $orderCollecion = $this->orderCollectionFactory
+            ->create()
+            ->addFieldToSelect('*');
+
+        $orderCollecion
+            ->addAttributeToFilter('customer_is_guest', ['eq' => 1])
+            ->addAttributeToFilter('guest_order_exported', ['null' => null]);
+        return $orderCollecion;
+    }
+
+    /**
+     * Export Guest Orders
+     *
+     * @return array
+     */
+    public function exportGuestOrders()
+    {
+        $response = [];
+        $orderCollection = $this->getGuestOrders();
+        foreach ($orderCollection as $guestOrder) {
+            $response[] = $this->export($guestOrder);
+        }
+        return $response;
+    }
+
+    /**
+     * @param \Magento\Sales\Model\Order $guestOrder
+     * @return mixed
+     */
+    public function export($guestOrder)
+    {
+        $response = [];
+        try {
+            $attributes = [
+                'metadata' => ['site' => $guestOrder->getStore()->getBaseUrl()]
+            ];
+
+            $attributes['email'] = $guestOrder->getCustomerEmail();
+            $attributes['description'] = 'guest';
+
+            $stripeAdapter = $this->adapterFactory->create();
+            $cs = $stripeAdapter->customer($attributes);
+
+            $transactionId = $guestOrder->getPayment()->getCcTransId();
+            $paymentIntent = $stripeAdapter->retrievePaymentIntent($transactionId);
+
+            $stripeAdapter->retrievePaymentIntent($paymentIntent->id);
+            $cid = $paymentIntent->customer;
+            $arrayParams = [
+                'email' => $guestOrder->getCustomerEmail(),
+            ];
+            $stripeAdapter->updateCustomer($cid, $arrayParams);
+            $guestOrder->setGuestOrderExported(1)->save();
+
+        } catch (\Exception $e) {
+            $response[] = ['error' => ['message' => $e->getMessage()]];
+        }
+        return $response;
+    }
+}

--- a/Model/Order/Guest.php
+++ b/Model/Order/Guest.php
@@ -8,9 +8,10 @@ use Magento\Sales\Model\ResourceModel\Order\Collection;
 use TNW\Stripe\Helper\Customer as CustomerHelper;
 use TNW\Stripe\Model\Adapter\StripeAdapterFactory;
 use TNW\Stripe\Helper\Payment\Formatter;
+
 /**
  * Class Guest
- * @package TNW\Stripe\Model\Order
+ * Guest orders actializer in Stripe.
  */
 class Guest
 {
@@ -52,17 +53,11 @@ class Guest
      */
     public function getGuestOrders()
     {
-        /**
-         * @var Collection $orderCollecion
-         */
-        $orderCollecion = $this->orderCollectionFactory
+        return $this->orderCollectionFactory
             ->create()
-            ->addFieldToSelect('*');
-
-        $orderCollecion
+            ->addFieldToSelect('*')
             ->addAttributeToFilter('customer_is_guest', ['eq' => 1])
             ->addAttributeToFilter('guest_order_exported', ['null' => null]);
-        return $orderCollecion;
     }
 
     /**
@@ -73,8 +68,7 @@ class Guest
     public function exportGuestOrders()
     {
         $response = [];
-        $orderCollection = $this->getGuestOrders();
-        foreach ($orderCollection as $guestOrder) {
+        foreach ($this->getGuestOrders() as $guestOrder) {
             $response[] = $this->export($guestOrder);
         }
         return $response;

--- a/Model/Order/Guest.php
+++ b/Model/Order/Guest.php
@@ -108,7 +108,6 @@ class Guest
             ];
             $stripeAdapter->updateCustomer($cid, $arrayParams);
             $guestOrder->setGuestOrderExported(1)->save();
-
         } catch (\Exception $e) {
             $response[] = ['error' => ['message' => $e->getMessage()]];
         }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -5,9 +5,16 @@
  */
 namespace TNW\Stripe\Setup;
 
+use Magento\Customer\Model\Customer;
+use Magento\Eav\Model\Config;
+use Magento\Customer\Setup\CustomerSetup;
+use Magento\Customer\Setup\CustomerSetupFactory;
+use Magento\Eav\Setup\EavSetupFactory;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\UpgradeDataInterface;
+use Magento\Eav\Api\Data\AttributeSetInterfaceFactory;
+use Magento\Sales\Setup\SalesSetupFactory;
 
 /**
  * Class UpgradeData
@@ -16,6 +23,53 @@ use Magento\Framework\Setup\UpgradeDataInterface;
  */
 class UpgradeData implements UpgradeDataInterface
 {
+    /**
+     * @var EavSetupFactory
+     */
+    protected $eavSetupFactory;
+
+    /**
+     * @var Config
+     */
+    protected $eavConfig;
+
+    /**
+     * @var CustomerSetupFactory
+     */
+    protected $customerSetupFactory;
+
+    /**
+     * @var AttributeSetInterfaceFactory
+     */
+    protected $attributeSetFactory;
+
+    /**
+     * @var SalesSetupFactory
+     */
+    protected $salesSetupFactory;
+
+    /**
+     * UpgradeData constructor.
+     * @param EavSetupFactory $eavSetupFactory
+     * @param CustomerSetupFactory $customerSetupFactory
+     * @param AttributeSetInterfaceFactory $attributeSetFactory
+     * @param SalesSetupFactory $salesSetupFactory
+     * @param Config $eavConfig
+     */
+    public function __construct(
+        EavSetupFactory $eavSetupFactory,
+        CustomerSetupFactory $customerSetupFactory,
+        AttributeSetInterfaceFactory $attributeSetFactory,
+        SalesSetupFactory $salesSetupFactory,
+        Config $eavConfig
+    ) {
+        $this->eavSetupFactory = $eavSetupFactory;
+        $this->customerSetupFactory = $customerSetupFactory;
+        $this->attributeSetFactory = $attributeSetFactory;
+        $this->salesSetupFactory = $salesSetupFactory;
+        $this->eavConfig = $eavConfig;
+    }
+
     /**
      * {@inheritdoc}
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
@@ -30,6 +84,13 @@ class UpgradeData implements UpgradeDataInterface
             $this->version_2_1_7($context, $setup);
         }
 
+        if (version_compare($context->getVersion(), "2.3.2", "<=")) {
+            $this->version_2_3_2($setup);
+        }
+
+        if (version_compare($context->getVersion(), "2.3.3", "<=")) {
+            $this->version_2_3_3($setup);
+        }
         $setup->endSetup();
     }
 
@@ -47,6 +108,68 @@ class UpgradeData implements UpgradeDataInterface
                 'scope_id' => 0,
                 'path' => 'tnw_module-stripe/survey/start_date',
                 'value' => date_create()->modify('+7 day')->getTimestamp()
+            ]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function version_2_3_2(
+        ModuleDataSetupInterface $setup
+    ) {
+        $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
+        $eavSetup->removeAttribute(
+            \Magento\Customer\Model\Customer::ENTITY,
+            'stripe_id'
+        );
+        /** @var CustomerSetup $customerSetup */
+        $customerSetup = $this->customerSetupFactory->create(['setup' => $setup]);
+
+        $customerEntity = $customerSetup->getEavConfig()->getEntityType('customer');
+        $attributeSetId = $customerEntity->getDefaultAttributeSetId();
+
+        /** @var $attributeSet AttributeSet */
+        $attributeSet = $this->attributeSetFactory->create();
+        $attributeGroupId = $attributeSet->getDefaultGroupId($attributeSetId);
+
+        $customerSetup->addAttribute(Customer::ENTITY, 'stripe_id', [
+            'type' => 'varchar',
+            'label' => 'Stripe Id',
+            'input' => 'text',
+            'required' => false,
+            'visible' => true,
+            'user_defined' => true,
+            'sort_order' => 1000,
+            'position' => 1000,
+            'system' => 0,
+        ]);
+        //add attribute to attribute set
+        $attribute = $customerSetup->getEavConfig()->getAttribute(Customer::ENTITY, 'stripe_id')
+            ->addData([
+                'attribute_set_id' => $attributeSetId,
+                'attribute_group_id' => $attributeGroupId,
+                'used_in_forms' => ['adminhtml_customer'],
+            ]);
+
+        $attribute->save();
+    }
+
+    /**
+     * @param $setup
+     */
+    protected function version_2_3_3($setup)
+    {
+        /** @var \Magento\Sales\Setup\SalesSetup $salesInstaller */
+        $salesInstaller = $this->salesSetupFactory->create(['resourceName' => 'sales_setup', 'setup' => $setup]);
+        $salesInstaller->addAttribute(
+            'order',
+            'guest_order_exported',
+            [
+                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'length'=> 255,
+                'visible' => false,
+                'nullable' => true
             ]
         );
     }

--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -15,11 +15,10 @@ use Magento\Framework\Setup\ModuleDataSetupInterface;
 use Magento\Framework\Setup\UpgradeDataInterface;
 use Magento\Eav\Api\Data\AttributeSetInterfaceFactory;
 use Magento\Sales\Setup\SalesSetupFactory;
+use Magento\Framework\DB\Ddl\Table;
 
 /**
  * Class UpgradeData
- *
- * @package TNW\QuickbooksBasic\Setup
  */
 class UpgradeData implements UpgradeDataInterface
 {
@@ -84,12 +83,8 @@ class UpgradeData implements UpgradeDataInterface
             $this->version_2_1_7($context, $setup);
         }
 
-        if (version_compare($context->getVersion(), "2.3.2", "<=")) {
+        if (version_compare($context->getVersion(), "2.3.2", "<")) {
             $this->version_2_3_2($setup);
-        }
-
-        if (version_compare($context->getVersion(), "2.3.3", "<=")) {
-            $this->version_2_3_3($setup);
         }
         $setup->endSetup();
     }
@@ -120,7 +115,7 @@ class UpgradeData implements UpgradeDataInterface
     ) {
         $eavSetup = $this->eavSetupFactory->create(['setup' => $setup]);
         $eavSetup->removeAttribute(
-            \Magento\Customer\Model\Customer::ENTITY,
+            Customer::ENTITY,
             'stripe_id'
         );
         /** @var CustomerSetup $customerSetup */
@@ -145,28 +140,21 @@ class UpgradeData implements UpgradeDataInterface
             'system' => 0,
         ]);
         //add attribute to attribute set
-        $attribute = $customerSetup->getEavConfig()->getAttribute(Customer::ENTITY, 'stripe_id')
+        $customerSetup->getEavConfig()->getAttribute(Customer::ENTITY, 'stripe_id')
             ->addData([
                 'attribute_set_id' => $attributeSetId,
                 'attribute_group_id' => $attributeGroupId,
                 'used_in_forms' => ['adminhtml_customer'],
-            ]);
+            ])
+            ->save();
 
-        $attribute->save();
-    }
-
-    /**
-     * @param $setup
-     */
-    protected function version_2_3_3($setup)
-    {
         /** @var \Magento\Sales\Setup\SalesSetup $salesInstaller */
         $salesInstaller = $this->salesSetupFactory->create(['resourceName' => 'sales_setup', 'setup' => $setup]);
         $salesInstaller->addAttribute(
             'order',
             'guest_order_exported',
             [
-                'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                'type' => Table::TYPE_TEXT,
                 'length'=> 255,
                 'visible' => false,
                 'nullable' => true

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnw/module-stripe",
   "description": "Stripe Payments for Magento 2",
   "type": "magento2-module",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "license": "OSL-3.0",
   "require": {
     "magento/framework": ">100",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "tnw/module-stripe",
   "description": "Stripe Payments for Magento 2",
   "type": "magento2-module",
-  "version": "2.3.3",
+  "version": "2.3.2",
   "license": "OSL-3.0",
   "require": {
     "magento/framework": ">100",

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -372,4 +372,12 @@
       <argument name="config" xsi:type="object">TNW\Stripe\Gateway\Config\Config</argument>
     </arguments>
   </type>
+
+    <type name="Magento\Framework\Console\CommandList">
+        <arguments>
+            <argument name="commands" xsi:type="array">
+                <item name="stripeOrder" xsi:type="object">TNW\Stripe\Console\Command\GuestOrder</item>
+            </argument>
+        </arguments>
+    </type>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="TNW_Stripe" setup_version="2.3.4">
+  <module name="TNW_Stripe" setup_version="2.3.3">
     <sequence>
       <module name="Magento_Customer"/>
       <module name="Magento_Payment"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="TNW_Stripe" setup_version="2.3.2">
+  <module name="TNW_Stripe" setup_version="2.3.3">
     <sequence>
       <module name="Magento_Customer"/>
       <module name="Magento_Payment"/>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -16,7 +16,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="TNW_Stripe" setup_version="2.3.3">
+  <module name="TNW_Stripe" setup_version="2.3.4">
     <sequence>
       <module name="Magento_Customer"/>
       <module name="Magento_Payment"/>

--- a/view/frontend/web/js/view/payment/adapter.js
+++ b/view/frontend/web/js/view/payment/adapter.js
@@ -122,6 +122,10 @@ define([
         createPaymentIntent: function () {
             var self = this,
                 dfd = $.Deferred();
+            if ($("#tnw_stripe_enable_vault").length) {
+                console.log(customerData);
+                arguments[0].vaultEnabled = $('#tnw_stripe_enable_vault').is(':checked');
+            }
             $.post(
                 self.getCreateUrl(),
                 {data: JSON.stringify(arguments[0])}
@@ -214,7 +218,7 @@ define([
                     if (result.paymentIntent.status == "requires_action"
                         || result.paymentIntent.status == "requires_source_action")
                     {
-                            return self.handleCardAction(paymentIntentId, done);
+                        return self.handleCardAction(paymentIntentId, done);
                     }
                     return done(false, result);
                 });

--- a/view/frontend/web/js/view/payment/adapter.js
+++ b/view/frontend/web/js/view/payment/adapter.js
@@ -123,7 +123,6 @@ define([
             var self = this,
                 dfd = $.Deferred();
             if ($("#tnw_stripe_enable_vault").length) {
-                console.log(customerData);
                 arguments[0].vaultEnabled = $('#tnw_stripe_enable_vault').is(':checked');
             }
             $.post(
@@ -218,7 +217,7 @@ define([
                     if (result.paymentIntent.status == "requires_action"
                         || result.paymentIntent.status == "requires_source_action")
                     {
-                        return self.handleCardAction(paymentIntentId, done);
+                            return self.handleCardAction(paymentIntentId, done);
                     }
                     return done(false, result);
                 });


### PR DESCRIPTION
- In `view/frontend/web/js/view/payment/adapter.js` I get  enable_vault checkbox value to transfer in Payment Intent Create Controller
- In Payment Intent Create controller i handle enable_vault value and set email and description for guest and customers logged in
- In `Gateway/Helper/SubjectReader.php` I created method for getting from payment order id from payment and format it.
- In `Gateway/Request/PaymentDataBuilder.php` I set order id to description in case when payment intent does not create
- In `Model/Adapter/StripeAdapter.php` I update description in case: extension use existing payment intent